### PR TITLE
Update runner to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
Github has deprecated Node12 for actions ([blog post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/))


![image](https://user-images.githubusercontent.com/58997957/197770119-740cdf8c-4fe3-43de-9693-4fabacb7403b.png)
