### PR TITLE
Update to Node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: false
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
GitHub has Deprecated node16 and is encouraging people to update to node20. GitHub plans to [stop supporting node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) in Spring 2024.